### PR TITLE
Order query to fetch entries and content types

### DIFF
--- a/read/contentful.go
+++ b/read/contentful.go
@@ -18,7 +18,7 @@ func (c *Contentful) Types() (rc io.ReadCloser, err error) {
 
 	return c.get("/spaces/" +
 		c.ReadConfig.SpaceID + "/content_types?access_token=" +
-		c.ReadConfig.AccessToken + "&limit=200&locale=" +
+		c.ReadConfig.AccessToken + "&limit=200&order=sys.createdAt&locale=" +
 		c.ReadConfig.Locale)
 }
 
@@ -27,7 +27,7 @@ func (c *Contentful) Items(skip int) (rc io.ReadCloser, err error) {
 
 	return c.get("/spaces/" +
 		c.ReadConfig.SpaceID + "/entries?access_token=" +
-		c.ReadConfig.AccessToken + "&limit=200&locale=" +
+		c.ReadConfig.AccessToken + "&limit=200&order=sys.createdAt&locale=" +
 		c.ReadConfig.Locale + "&skip=" + strconv.Itoa(skip))
 }
 


### PR DESCRIPTION
By ordering the fetching of entries we prevent items being on several pages. This doesn't seem to be an issue up to 1500/2000 entries but for our 6k entries we only ended up with 4k unique entries downloaded.

This fixes it. 